### PR TITLE
reflect: add GitHub Actions test workflow

### DIFF
--- a/.github/workflows/reflect.yml
+++ b/.github/workflows/reflect.yml
@@ -1,0 +1,35 @@
+# Copyright 2022 The golang.design Initiative Authors.
+# All rights reserved. Use of this source code is governed
+# by a MIT license that can be found in the LICENSE file.
+#
+# Written by Changkun Ou <changkun.de>
+
+name: reflect
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    name: test (${{ matrix.os }}, go${{ matrix.go }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        go: [ '1.24.x', 'stable' ]
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go }}
+      - name: go vet
+        run: go vet ./...
+      - name: go test
+        run: go test -v -covermode=atomic ./...


### PR DESCRIPTION
Run go vet and go test across Linux/macOS/Windows on Go 1.24.x and stable, on push and pull request. There was no CI before, which is why the open PRs sat unchecked.