### PR TITLE
reflect: add copy customization options (WithCopyFunc, RetainTypes, ZeroTypes)

### DIFF
--- a/customcopy_test.go
+++ b/customcopy_test.go
@@ -1,0 +1,94 @@
+// Copyright 2022 The golang.design Initiative Authors.
+// All rights reserved. Use of this source code is governed
+// by a MIT license that can be found in the LICENSE file.
+
+package reflect
+
+import (
+	"sync"
+	"testing"
+)
+
+type singleton struct{ id int }
+
+// TestRetainTypes verifies that RetainTypes keeps a value shared by reference
+// in the copy instead of deep copying it (the singleton case from #51520).
+func TestRetainTypes(t *testing.T) {
+	shared := &singleton{id: 42}
+	src := struct {
+		S    *singleton
+		Data []int
+	}{S: shared, Data: []int{1, 2, 3}}
+
+	// Without the option, the singleton is deep copied (different pointer).
+	plain := DeepCopy(src)
+	if plain.S == shared {
+		t.Fatal("without RetainTypes the singleton should be deep copied")
+	}
+
+	// With the option, the singleton pointer is retained.
+	dst := DeepCopy(src, RetainTypes(shared))
+	if dst.S != shared {
+		t.Fatalf("RetainTypes should share the singleton: got %p, want %p", dst.S, shared)
+	}
+	// Surrounding data is still deep copied.
+	if &dst.Data[0] == &src.Data[0] {
+		t.Fatal("non-retained data should still be deep copied")
+	}
+}
+
+// TestZeroTypes verifies that ZeroTypes substitutes a fresh zero value, so a
+// copied sync.Mutex comes back unlocked (the stateful-object case from #51520).
+func TestZeroTypes(t *testing.T) {
+	type guarded struct {
+		mu  sync.Mutex
+		val int
+	}
+	src := &guarded{val: 7}
+	src.mu.Lock() // src is held
+
+	dst := DeepCopy(src, ZeroTypes(sync.Mutex{}))
+	if dst.val != 7 {
+		t.Fatalf("non-zeroed field should be copied: got %d, want 7", dst.val)
+	}
+	if !dst.mu.TryLock() {
+		t.Fatal("ZeroTypes should reset the copied mutex to unlocked")
+	}
+	dst.mu.Unlock()
+	src.mu.Unlock()
+}
+
+// TestWithCopyFunc verifies the general escape hatch with a concrete type.
+func TestWithCopyFunc(t *testing.T) {
+	type box struct{ n int }
+	src := &box{n: 1}
+	dst := DeepCopy(src, WithCopyFunc(func(b *box) *box {
+		return &box{n: b.n + 100}
+	}))
+	if dst.n != 101 {
+		t.Fatalf("WithCopyFunc not applied: got %d, want 101", dst.n)
+	}
+}
+
+type animal interface{ sound() string }
+
+type dog struct{ name string }
+
+func (d *dog) sound() string { return "woof" }
+
+// TestWithCopyFuncInterface verifies that an interface-typed WithCopyFunc
+// applies to values whose dynamic type implements the interface.
+func TestWithCopyFuncInterface(t *testing.T) {
+	src := struct{ A animal }{A: &dog{name: "rex"}}
+	called := false
+	dst := DeepCopy(src, WithCopyFunc(func(a animal) animal {
+		called = true
+		return a // share
+	}))
+	if !called {
+		t.Fatal("interface WithCopyFunc was not invoked for implementing type")
+	}
+	if dst.A != src.A {
+		t.Fatal("interface WithCopyFunc returning the source should share it")
+	}
+}

--- a/deepcopy.go
+++ b/deepcopy.go
@@ -24,6 +24,32 @@ type copyConfig struct {
 	disallowCopyCircular          bool
 	disallowCopyBidirectionalChan bool
 	disallowCopyTypes             []reflect.Type
+	copyFuncs                     []copyFuncEntry
+}
+
+// copyFuncEntry binds a type (concrete or interface) to a custom copy
+// function that replaces the default deep copy behavior for that type.
+type copyFuncEntry struct {
+	typ reflect.Type
+	fn  func(src any) (dst any)
+}
+
+// customCopy returns the custom copy function registered for srcType, if any.
+// An exact (concrete) type match takes precedence over an interface match;
+// among interfaces the first registered match wins.
+func (c *copyConfig) customCopy(srcType reflect.Type) (func(any) any, bool) {
+	var iface func(any) any
+	found := false
+	for i := range c.copyFuncs {
+		e := c.copyFuncs[i]
+		if e.typ == srcType {
+			return e.fn, true
+		}
+		if !found && e.typ.Kind() == reflect.Interface && srcType.Implements(e.typ) {
+			iface, found = e.fn, true
+		}
+	}
+	return iface, found
 }
 
 // DisallowCopyUnexported returns a DeepCopyOption that disables the behavior
@@ -56,6 +82,54 @@ func DisallowTypes(val ...any) DeepCopyOption {
 	return func(opt *copyConfig) {
 		for i := range val {
 			opt.disallowCopyTypes = append(opt.disallowCopyTypes, reflect.TypeOf(val[i]))
+		}
+	}
+}
+
+// WithCopyFunc returns a DeepCopyOption that replaces the default deep copy
+// behavior for values of type T with fn. This is the general escape hatch for
+// types that must not be copied by their memory representation, such as
+// singletons that must remain shared, or stateful objects like sync.Mutex,
+// os.File, net.Conn, and js.Value.
+//
+// T may be a concrete type or an interface type. When T is an interface, fn
+// applies to every value whose dynamic type implements T (unless a more
+// specific concrete WithCopyFunc is also registered for that value's type).
+//
+// RetainTypes and ZeroTypes are convenience wrappers over WithCopyFunc.
+func WithCopyFunc[T any](fn func(src T) (dst T)) DeepCopyOption {
+	t := reflect.TypeOf((*T)(nil)).Elem()
+	wrapped := func(src any) any { return fn(src.(T)) }
+	return func(opt *copyConfig) {
+		opt.copyFuncs = append(opt.copyFuncs, copyFuncEntry{t, wrapped})
+	}
+}
+
+// RetainTypes returns a DeepCopyOption that retains (shares by reference) the
+// values of the given types instead of deep copying them. Use it for pointers
+// to singletons that must remain singletons in the copied result.
+func RetainTypes(val ...any) DeepCopyOption {
+	return func(opt *copyConfig) {
+		for i := range val {
+			t := reflect.TypeOf(val[i])
+			opt.copyFuncs = append(opt.copyFuncs, copyFuncEntry{
+				t, func(src any) any { return src },
+			})
+		}
+	}
+}
+
+// ZeroTypes returns a DeepCopyOption that substitutes a fresh zero value for
+// the values of the given types instead of deep copying them. Use it for
+// stateful objects whose copied state would be invalid or dangerous to share,
+// such as resetting a sync.Mutex to its unlocked state.
+func ZeroTypes(val ...any) DeepCopyOption {
+	return func(opt *copyConfig) {
+		for i := range val {
+			t := reflect.TypeOf(val[i])
+			opt.copyFuncs = append(opt.copyFuncs, copyFuncEntry{
+				t, func(src any) any { return reflect.Zero(t).Interface() },
+			})
 		}
 	}
 }
@@ -126,6 +200,12 @@ func copyAny(src any, ptrs map[uintptr]any, copyConf *copyConfig) (dst any) {
 	v := reflect.ValueOf(src)
 	if !v.IsValid() {
 		return src
+	}
+
+	// A caller-provided copy function overrides the default behavior for
+	// its type, e.g. retaining singletons or zeroing stateful objects.
+	if fn, ok := copyConf.customCopy(v.Type()); ok {
+		return fn(src)
 	}
 
 	// Look up the corresponding copy function.


### PR DESCRIPTION
Address the one genuine library gap from the go.dev/issue/51520 discussion:
singletons and stateful objects (rsc: pointers to singletons must stay shared,
not copied; davecheney: locked mutex / shared fd; atdiar: js.Value).

Until now the only knob for specific types was DisallowTypes, which panics.
This adds, in the existing declarative DeepCopyOption style (no Clone-like
interface, per the proposal discussion):

- WithCopyFunc[T](fn) — general per-type escape hatch; T may be concrete or an
  interface (applies to any dynamic type implementing it).
- RetainTypes(vals...) — share the given types by reference (keep singletons).
- ZeroTypes(vals...) — substitute a fresh zero value (e.g. unlocked mutex).

RetainTypes and ZeroTypes are thin wrappers over WithCopyFunc.

Tests cover sharing a singleton, zeroing a locked sync.Mutex, a concrete
custom func, and interface-based matching.