### PR TITLE
reflect: document API, options and design notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,52 +1,92 @@
 # reflect
 
-Package reflect implements the proposal [go.dev/issue/51520](https://go.dev/issue/51520).
+[![PkgGoDev](https://pkg.go.dev/badge/golang.design/x/reflect)](https://pkg.go.dev/golang.design/x/reflect)
+
+Package reflect provides a generic `DeepCopy` for Go, the external
+implementation of proposal [go.dev/issue/51520](https://go.dev/issue/51520).
 
 ```go
-// DeepCopy copies src to dst recursively.
-//
-// Two values of identical type are deeply copied if one of the following
-// cases apply.
-//
-// Numbers, bools, strings are deeply copied and have different underlying
-// memory address.
-//
-// Slice and Array values are deeply copied, including its elements.
-//
-// Map values are deeply copied for all of its key and corresponding
-// values.
-//
-// Pointer values are deeply copied for their pointed value, and the
-// pointer points to the deeply copied value.
-//
-// Struct values are deeply copied for all fields, including exported
-// and unexported.
-//
-// Interface values are deeply copied if the underlying type can be
-// deeply copied.
-//
-// There are a few exceptions that may result in a deeply copied value not
-// deeply equal (asserted by DeepEqual(dst, src)) to the source value:
-//
-// 1) Func values are still refer to the same function
-// 2) Chan values are replaced by newly created channels
-// 3) One-way Chan values (receive or read-only) values are still refer
-//    to the same channel
-//
-// Note that while correct uses of DeepCopy do exist, they are not rare.
-// The use of DeepCopy often indicates the copying object does not contain
-// a singleton or is never meant to be copied, such as sync.Mutex, os.File,
-// net.Conn, js.Value, etc. In these cases, the copied value retains the
-// memory representations of the source value but may result in unexpected
-// consequences in follow-up usage, the caller should clear these values
-// depending on their usage context.
-//
-// To change these predefined behaviors, use provided DeepCopyOption.
+import "golang.design/x/reflect"
+```
+
+## Usage
+
+```go
+src := &Node{Val: 1, Next: &Node{Val: 2}}
+dst := reflect.DeepCopy(src) // a fully independent copy
+```
+
+`DeepCopy` copies `src` to a freshly allocated value of the same type and
+returns it:
+
+```go
 func DeepCopy[T any](src T, opts ...DeepCopyOption) (dst T)
 ```
 
-_Warning_: Not largely tested. Use it with care.
+Two values of identical type are deeply copied as follows:
+
+- Numbers, bools and strings are copied and have a different underlying memory
+  address.
+- Slices and arrays are deeply copied, including their elements.
+- Maps are deeply copied for all keys and values.
+- Pointers are deeply copied for the pointed value, and the copy points to the
+  deeply copied value.
+- Structs are deeply copied for all fields, including unexported ones.
+- Interfaces are deeply copied if the underlying type can be deeply copied.
+
+A few cases mean a deeply copied value is not necessarily `DeepEqual` to the
+source:
+
+1. Func values still refer to the same function.
+2. Bidirectional channels are replaced by newly created channels.
+3. One-way (send- or receive-only) channels still refer to the same channel.
+
+## Customization
+
+Stateful objects (`sync.Mutex`, `os.File`, `net.Conn`, `js.Value`, ...) and
+singletons should usually not be copied by their memory representation. Use the
+following options to override the default behavior per type:
+
+```go
+dst := reflect.DeepCopy(src,
+	// Keep a singleton shared by reference instead of copying it.
+	reflect.RetainTypes(theSingleton),
+	// Reset a stateful value to its zero value (e.g. an unlocked mutex).
+	reflect.ZeroTypes(sync.Mutex{}),
+	// General escape hatch: provide arbitrary per-type copy logic. T may be a
+	// concrete type or an interface (applies to any implementing dynamic type).
+	reflect.WithCopyFunc(func(c net.Conn) net.Conn { return reconnect(c) }),
+)
+```
+
+`RetainTypes` and `ZeroTypes` are thin wrappers over `WithCopyFunc`.
+
+Additional options control structural behavior:
+
+- `DisallowCopyUnexported()` skips unexported struct fields instead of copying them.
+- `DisallowCopyCircular()` panics on circular structures instead of handling them.
+- `DisallowCopyBidirectionalChan()` keeps the source channel instead of creating a new one.
+- `DisallowTypes(vals...)` panics if a value of the given types is encountered.
+
+## Design notes
+
+These answer the questions raised in
+[go.dev/issue/51520](https://go.dev/issue/51520):
+
+- **Circular and shared structures** are handled by tracking already-copied
+  pointers, so the copy preserves the original pointer aliasing. Opt out with
+  `DisallowCopyCircular()`.
+- **The destination can never alias the source.** `DeepCopy` always allocates a
+  fresh result, so the "destination reachable from source" hazard does not arise.
+- **Unexported fields** are copied (this requires the `unsafe` package, since
+  `reflect` cannot set unexported fields directly). Opt out with
+  `DisallowCopyUnexported()`.
+- **Singletons and stateful objects** are the cases where blindly copying memory
+  is wrong; `RetainTypes`, `ZeroTypes` and `WithCopyFunc` exist to handle them
+  without baking a `Clone`-style interface into the type system.
+- **Cost.** Deep copy is not free: it allocates roughly one allocation per
+  copied element. See `bench_test.go`. Prefer a hand-written copy on hot paths.
 
 ## License
 
-MIT | &copy; 2022 The golang.design Initiative Authors, written by Changkun Ou.
+MIT | &copy; 2022 The golang.design Initiative Authors, written by [Changkun Ou](https://changkun.de).


### PR DESCRIPTION
Refresh the README now that the package has tests, CI and customization options:

- Document DeepCopy semantics and the full option set (WithCopyFunc, RetainTypes, ZeroTypes, and the Disallow* options).
- Add a Design notes section that records how the package answers the questions from go.dev/issue/51520 (circular structures, dst never aliases src, unexported fields, singletons/stateful objects, cost).
- Drop the stale 'Not largely tested. Use it with care.' warning.