### PR TITLE
reflect: make type-scoped options generic and singular

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,23 +50,25 @@ following options to override the default behavior per type:
 ```go
 dst := reflect.DeepCopy(src,
 	// Keep a singleton shared by reference instead of copying it.
-	reflect.RetainTypes(theSingleton),
+	reflect.RetainType[*Config](),
 	// Reset a stateful value to its zero value (e.g. an unlocked mutex).
-	reflect.ZeroTypes(sync.Mutex{}),
+	reflect.ZeroType[sync.Mutex](),
 	// General escape hatch: provide arbitrary per-type copy logic. T may be a
 	// concrete type or an interface (applies to any implementing dynamic type).
 	reflect.WithCopyFunc(func(c net.Conn) net.Conn { return reconnect(c) }),
 )
 ```
 
-`RetainTypes` and `ZeroTypes` are thin wrappers over `WithCopyFunc`.
+The type parameter may be a concrete type or an interface; an interface applies
+to every value whose dynamic type implements it. `RetainType` and `ZeroType` are
+thin wrappers over `WithCopyFunc`.
 
 Additional options control structural behavior:
 
 - `DisallowCopyUnexported()` skips unexported struct fields instead of copying them.
 - `DisallowCopyCircular()` panics on circular structures instead of handling them.
 - `DisallowCopyBidirectionalChan()` keeps the source channel instead of creating a new one.
-- `DisallowTypes(vals...)` panics if a value of the given types is encountered.
+- `DisallowType[T]()` panics if a value of type T (concrete or interface) is encountered.
 
 ## Design notes
 
@@ -82,7 +84,7 @@ These answer the questions raised in
   `reflect` cannot set unexported fields directly). Opt out with
   `DisallowCopyUnexported()`.
 - **Singletons and stateful objects** are the cases where blindly copying memory
-  is wrong; `RetainTypes`, `ZeroTypes` and `WithCopyFunc` exist to handle them
+  is wrong; `RetainType`, `ZeroType` and `WithCopyFunc` exist to handle them
   without baking a `Clone`-style interface into the type system.
 - **Cost.** Deep copy is not free: it allocates roughly one allocation per
   copied element. See `bench_test.go`. Prefer a hand-written copy on hot paths.

--- a/customcopy_test.go
+++ b/customcopy_test.go
@@ -11,9 +11,9 @@ import (
 
 type singleton struct{ id int }
 
-// TestRetainTypes verifies that RetainTypes keeps a value shared by reference
+// TestRetainType verifies that RetainType keeps a value shared by reference
 // in the copy instead of deep copying it (the singleton case from #51520).
-func TestRetainTypes(t *testing.T) {
+func TestRetainType(t *testing.T) {
 	shared := &singleton{id: 42}
 	src := struct {
 		S    *singleton
@@ -23,13 +23,13 @@ func TestRetainTypes(t *testing.T) {
 	// Without the option, the singleton is deep copied (different pointer).
 	plain := DeepCopy(src)
 	if plain.S == shared {
-		t.Fatal("without RetainTypes the singleton should be deep copied")
+		t.Fatal("without RetainType the singleton should be deep copied")
 	}
 
 	// With the option, the singleton pointer is retained.
-	dst := DeepCopy(src, RetainTypes(shared))
+	dst := DeepCopy(src, RetainType[*singleton]())
 	if dst.S != shared {
-		t.Fatalf("RetainTypes should share the singleton: got %p, want %p", dst.S, shared)
+		t.Fatalf("RetainType should share the singleton: got %p, want %p", dst.S, shared)
 	}
 	// Surrounding data is still deep copied.
 	if &dst.Data[0] == &src.Data[0] {
@@ -37,9 +37,9 @@ func TestRetainTypes(t *testing.T) {
 	}
 }
 
-// TestZeroTypes verifies that ZeroTypes substitutes a fresh zero value, so a
+// TestZeroType verifies that ZeroType substitutes a fresh zero value, so a
 // copied sync.Mutex comes back unlocked (the stateful-object case from #51520).
-func TestZeroTypes(t *testing.T) {
+func TestZeroType(t *testing.T) {
 	type guarded struct {
 		mu  sync.Mutex
 		val int
@@ -47,12 +47,12 @@ func TestZeroTypes(t *testing.T) {
 	src := &guarded{val: 7}
 	src.mu.Lock() // src is held
 
-	dst := DeepCopy(src, ZeroTypes(sync.Mutex{}))
+	dst := DeepCopy(src, ZeroType[sync.Mutex]())
 	if dst.val != 7 {
 		t.Fatalf("non-zeroed field should be copied: got %d, want 7", dst.val)
 	}
 	if !dst.mu.TryLock() {
-		t.Fatal("ZeroTypes should reset the copied mutex to unlocked")
+		t.Fatal("ZeroType should reset the copied mutex to unlocked")
 	}
 	dst.mu.Unlock()
 	src.mu.Unlock()
@@ -90,5 +90,30 @@ func TestWithCopyFuncInterface(t *testing.T) {
 	}
 	if dst.A != src.A {
 		t.Fatal("interface WithCopyFunc returning the source should share it")
+	}
+}
+
+// TestDisallowTypeInterface verifies that DisallowType works for interface
+// types, which the previous value-based DisallowTypes could not express
+// (reflect.TypeOf of a nil interface value is nil).
+func TestDisallowTypeInterface(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("DisallowType[animal] should panic on an implementing value")
+		}
+	}()
+	src := struct{ A animal }{A: &dog{name: "rex"}}
+	_ = DeepCopy(src, DisallowType[animal]())
+}
+
+// TestWithCopyFuncNilInterfaceField is a regression test: a WithCopyFunc that
+// returns a nil interface for a struct field must not panic when setting the
+// unexported field.
+func TestWithCopyFuncNilInterfaceField(t *testing.T) {
+	type holder struct{ a animal }
+	src := &holder{a: &dog{name: "rex"}}
+	dst := DeepCopy(src, WithCopyFunc(func(a animal) animal { return nil }))
+	if dst.a != nil {
+		t.Fatalf("expected nil interface field, got %v", dst.a)
 	}
 }

--- a/deepcopy.go
+++ b/deepcopy.go
@@ -6,7 +6,8 @@
 
 // Package reflect implements the proposal https://go.dev/issue/51520.
 //
-// Warning: Not largely tested. Use it with care.
+// It provides a generic DeepCopy and a set of DeepCopyOption values to
+// customize how singletons and stateful objects are copied.
 package reflect
 
 import (
@@ -76,13 +77,13 @@ func DisallowCopyBidirectionalChan() DeepCopyOption {
 	}
 }
 
-// DisallowTypes returns a DeepCopyOption that disallows copying any types
-// that are in given values.
-func DisallowTypes(val ...any) DeepCopyOption {
+// DisallowType returns a DeepCopyOption that panics when a value of type T is
+// encountered during copying. T may be a concrete type or an interface type;
+// for an interface, copying any value whose dynamic type implements T panics.
+func DisallowType[T any]() DeepCopyOption {
+	t := reflect.TypeOf((*T)(nil)).Elem()
 	return func(opt *copyConfig) {
-		for i := range val {
-			opt.disallowCopyTypes = append(opt.disallowCopyTypes, reflect.TypeOf(val[i]))
-		}
+		opt.disallowCopyTypes = append(opt.disallowCopyTypes, t)
 	}
 }
 
@@ -96,7 +97,7 @@ func DisallowTypes(val ...any) DeepCopyOption {
 // applies to every value whose dynamic type implements T (unless a more
 // specific concrete WithCopyFunc is also registered for that value's type).
 //
-// RetainTypes and ZeroTypes are convenience wrappers over WithCopyFunc.
+// RetainType and ZeroType are convenience wrappers over WithCopyFunc.
 func WithCopyFunc[T any](fn func(src T) (dst T)) DeepCopyOption {
 	t := reflect.TypeOf((*T)(nil)).Elem()
 	wrapped := func(src any) any { return fn(src.(T)) }
@@ -105,33 +106,22 @@ func WithCopyFunc[T any](fn func(src T) (dst T)) DeepCopyOption {
 	}
 }
 
-// RetainTypes returns a DeepCopyOption that retains (shares by reference) the
-// values of the given types instead of deep copying them. Use it for pointers
-// to singletons that must remain singletons in the copied result.
-func RetainTypes(val ...any) DeepCopyOption {
-	return func(opt *copyConfig) {
-		for i := range val {
-			t := reflect.TypeOf(val[i])
-			opt.copyFuncs = append(opt.copyFuncs, copyFuncEntry{
-				t, func(src any) any { return src },
-			})
-		}
-	}
+// RetainType returns a DeepCopyOption that retains (shares by reference) values
+// of type T instead of deep copying them. Use it for singletons that must
+// remain singletons in the copied result.
+//
+// RetainType matches by type: every value of type T is retained. To retain one
+// specific instance, use WithCopyFunc with an identity check on that value.
+func RetainType[T any]() DeepCopyOption {
+	return WithCopyFunc(func(src T) (dst T) { return src })
 }
 
-// ZeroTypes returns a DeepCopyOption that substitutes a fresh zero value for
-// the values of the given types instead of deep copying them. Use it for
-// stateful objects whose copied state would be invalid or dangerous to share,
-// such as resetting a sync.Mutex to its unlocked state.
-func ZeroTypes(val ...any) DeepCopyOption {
-	return func(opt *copyConfig) {
-		for i := range val {
-			t := reflect.TypeOf(val[i])
-			opt.copyFuncs = append(opt.copyFuncs, copyFuncEntry{
-				t, func(src any) any { return reflect.Zero(t).Interface() },
-			})
-		}
-	}
+// ZeroType returns a DeepCopyOption that substitutes a fresh zero value for
+// values of type T instead of deep copying them. Use it for stateful objects
+// whose copied state would be invalid or dangerous to share, such as resetting
+// a sync.Mutex to its unlocked state.
+func ZeroType[T any]() DeepCopyOption {
+	return WithCopyFunc(func(src T) (dst T) { return })
 }
 
 // DeepCopy copies src to dst recursively.
@@ -189,9 +179,10 @@ func DeepCopy[T any](src T, opts ...DeepCopyOption) (dst T) {
 }
 
 func copyAny(src any, ptrs map[uintptr]any, copyConf *copyConfig) (dst any) {
-	if len(copyConf.disallowCopyTypes) != 0 {
+	if srcType := reflect.TypeOf(src); srcType != nil {
 		for i := range copyConf.disallowCopyTypes {
-			if reflect.TypeOf(src) == copyConf.disallowCopyTypes[i] {
+			dt := copyConf.disallowCopyTypes[i]
+			if srcType == dt || (dt.Kind() == reflect.Interface && srcType.Implements(dt)) {
 				panic(fmt.Sprintf("reflect: deep copying type %T is disallowed", src))
 			}
 		}
@@ -340,7 +331,9 @@ func copyStruct(x any, ptrs map[uintptr]any, copyConf *copyConfig) any {
 			dc.Elem().Field(i).Set(reflect.ValueOf(item))
 		} else {
 			item := copyAny(valueInterfaceUnsafe(v.Field(i)), ptrs, copyConf)
-			setField(dc.Elem().Field(i), reflect.ValueOf(item))
+			if iv := reflect.ValueOf(item); iv.IsValid() {
+				setField(dc.Elem().Field(i), iv)
+			}
 		}
 	}
 	return dc.Elem().Interface()


### PR DESCRIPTION
Unify the type-scoped option family on the generic form, so types are
specified at compile time and interface types work correctly.

- RetainTypes(v...)   -> RetainType[T]()
- ZeroTypes(v...)     -> ZeroType[T]()
- DisallowTypes(v...) -> DisallowType[T]()

WithCopyFunc[T] is unchanged. RetainType and ZeroType are now thin wrappers
over it.

Why: the value-based forms could not express interface types at all, since
reflect.TypeOf(net.Conn(nil)) is nil, so DisallowTypes(net.Conn(nil)) and
friends silently registered nothing. The generic form derives the type via
reflect.TypeOf((*T)(nil)).Elem(), which yields interface types correctly, and
the disallow check now matches interfaces via Implements.

Also:
- guard the unexported-field set with IsValid so a WithCopyFunc returning a nil
  interface for a struct field no longer panics (regression test added)
- drop the stale 'Not largely tested' package doc warning

BREAKING: renames DisallowTypes (from #1) and the RetainTypes/ZeroTypes added
in #8. The package was just revived with no known dependents.