### PR TITLE
Fix when map values that are set as nil deleted after deepcopy

### DIFF
--- a/deepcopy.go
+++ b/deepcopy.go
@@ -283,7 +283,12 @@ func copyMap(x any, ptrs map[uintptr]any, copyConf *copyConfig) any {
 	for iter.Next() {
 		item := copyAny(iter.Value().Interface(), ptrs, copyConf)
 		k := copyAny(iter.Key().Interface(), ptrs, copyConf)
-		dc.SetMapIndex(reflect.ValueOf(k), reflect.ValueOf(item))
+		v := reflect.ValueOf(item)
+		if item == nil {
+			var nilV any
+			v = reflect.ValueOf(&nilV).Elem()
+		}
+		dc.SetMapIndex(reflect.ValueOf(k), v)
 	}
 	return dc.Interface()
 }

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -57,6 +57,7 @@ func TestDeepCopy(t *testing.T) {
 		}, // 10, more complex test
 		{uintptr(unsafe.Pointer(&aValidAddress))}, // 11, uintptr
 		// {unsafe.Pointer(&aValidAddress)},          // 12, unsafe.Pointer
+		{map[string]any{"1": nil, "2": "value"}}, // 13, map with nil values
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
Fixes #12 

The issue appears because `reflect.Value.SetMapIndex()` deletes key if value is zero. From [godoc](https://pkg.go.dev/reflect#Value.SetMapIndex):

> If elem is the zero Value, SetMapIndex deletes the key from the map.

I found [this workaround](https://github.com/golang/go/issues/34898#issuecomment-541753495) that fixes the issue and applied it in the fix.

PR adds test that fails on main branch and passes with the fix